### PR TITLE
Add reference name to get before load warning

### DIFF
--- a/lib/big-red.js
+++ b/lib/big-red.js
@@ -27,7 +27,7 @@ function attach(reference) {
 function get(referenceName) {
   if(!loadedCheck && !loadedWarning) {
     loadedWarning = true;
-    console.log('WARNING: You are accessing reference data without first checking if it has been loaded, this may or may not be a problem.');
+    console.log('WARNING: You are accessing reference data (%s) without first checking if it has been loaded, this may or may not be a problem.', referenceName);
   }
   return references[referenceName];
 }


### PR DESCRIPTION
Makes it easier to find what is causing the error.