### PR TITLE
Ensure callback only fires when the reference has been loaded, even if trying to load the same reference twice

### DIFF
--- a/lib/big-red.js
+++ b/lib/big-red.js
@@ -132,8 +132,8 @@ function load(toLoad, next) {
     } else {
       if(!references[reference].ticker) {
         references[reference].ticker = ticker(references[reference]);
-        anyLoaded = true;
       }
+      anyLoaded = true;
     }
   });
 

--- a/tests/big-red.test.js
+++ b/tests/big-red.test.js
@@ -326,4 +326,41 @@ describe('Big Red', function() {
 
     });
 
+    it("Callback doesn't fire before reference is loaded when load is called multiple times", function(done) {
+
+        var data = [
+          {id:'1', name:'Kermit', type:'frog'},
+          {id:'2', name:'Miss Piggy', type: 'pig'},
+          {id:'3', name:'Fozzie Bear', type: 'bear'}
+        ];
+
+        br.attach({
+          name:'muppets',
+          retriever: function(next) {
+            setTimeout(function () {
+              next(null, data);
+            }, 0);
+          },
+          poller:function(next) {
+            next();
+          }
+        });
+
+        var count = 0;
+
+        function calledBack () {
+          if (++count == 2) done();
+        }
+
+        br.load(['muppets'], function() {
+          expect(br.get('muppets').array).to.eql(data);
+          calledBack();
+        });
+
+        br.load(['muppets'], function() {
+          expect(br.get('muppets').array).to.eql(data);
+          calledBack();
+        });
+    });
+
 });


### PR DESCRIPTION
I noticed that the callback was being fired immediately if you loaded the same reference twice within the same process before it was loaded.