### PR TITLE
Revert "Allow using async get"

### DIFF
--- a/lib/big-red.js
+++ b/lib/big-red.js
@@ -24,16 +24,11 @@ function attach(reference) {
   references[reference.name] = reference;
 }
 
-function get(referenceName, next) {
+function get(referenceName) {
   if(!loadedCheck && !loadedWarning) {
     loadedWarning = true;
     console.log('WARNING: You are accessing reference data (%s) without first checking if it has been loaded, this may or may not be a problem.', referenceName);
   }
-
-  if (next) {
-    return next(null, references[referenceName]);
-  }
-
   return references[referenceName];
 }
 

--- a/tests/big-red.test.js
+++ b/tests/big-red.test.js
@@ -25,6 +25,7 @@ describe('Big Red', function() {
     });
 
     it("Can attach a reference configuration and immediately retrieve data", function(done) {
+
         var data = [
           {id:'1', name:'Kermit', type:'frog'},
           {id:'2', name:'Miss Piggy', type: 'pig'},
@@ -48,32 +49,7 @@ describe('Big Red', function() {
           expect(br.get('muppets').map['3']).to.eql(data[2]);
           done();
         });
-    });
 
-    it("Can attach a reference configuration and immediately retrieve data via async get", function(done) {
-        var data = [
-          {id:'1', name:'Kermit', type:'frog'},
-          {id:'2', name:'Miss Piggy', type: 'pig'},
-          {id:'3', name:'Fozzie Bear', type: 'bear'}
-        ];
-
-        br.attach({
-          name:'muppets',
-          retriever: function(next) {
-            next(null, data);
-          },
-          poller:function(next) {
-            next();
-          }
-        });
-
-        br.load(['muppets'], function() {
-          br.get('muppets', function(err, reference) {
-            expect(reference.array).to.eql(data);
-          });
-
-          done();
-        });
     });
 
      it("Can attach a reference configuration and immediately retrieve data that is a map and not an array", function(done) {


### PR DESCRIPTION
This reverts commit 0d880206736ad5619607d312ef1e4bdd89d67eff.

Do we need to have a function that can return its value either directly
or via callback?  If there is nothing async in the function, why have
the callback method

@gabceb @cliftonc 