### PR TITLE
Unref ticker so it doesn't prevent proces exiting

### DIFF
--- a/lib/big-red.js
+++ b/lib/big-red.js
@@ -40,7 +40,7 @@ function get(referenceName, next) {
 function ticker(reference) {
   reference.enabled = true;
   tick.bind(reference)(true);
-  return setInterval(tick.bind(reference), reference.interval);
+  return setInterval(tick.bind(reference), reference.interval).unref();
 }
 
 function tick(firstTick) {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "expect.js": "^0.3.1",
     "istanbul": "^0.3.7",
     "jshint": "^2.6.3",
-    "mocha": "^2.2.1",
+    "mocha": "^5.2.0",
     "precommit-hook": "^1.0.7"
   },
   "precommit": [

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "expect.js": "^0.3.1",
     "istanbul": "^0.3.7",
     "jshint": "^2.6.3",
-    "mocha": "^5.2.0",
+    "mocha": "^2.2.1",
     "precommit-hook": "^1.0.7"
   },
   "precommit": [


### PR DESCRIPTION
Unrefed timer will allow event loop to exit even if it has pending
callbacks for it.
This means processes using big red will be able to exit.

~~To demonstrate, I have bumped mocha, which no longer forces exit when
tests are finished. Without unref it just hangs, with unref it exits
cleanly after running tests.~~
I reverted mocha upgrade as it requires es6 and this appears to be an es5 project.

Shout out to @telekosmos for finding pending intervals...